### PR TITLE
Refactor (src/database/mongo/sorted/add.js): reduce complexity in sortedSetsAdd()

### DIFF
--- a/src/database/mongo/sorted/add.js
+++ b/src/database/mongo/sorted/add.js
@@ -4,72 +4,42 @@ module.exports = function (module) {
 	const helpers = require('../helpers');
 	const utils = require('../../../utils');
 
-	module.sortedSetAdd = async function (key, score, value) {
-		if (!key) {
-			return;
-		}
-		if (Array.isArray(score) && Array.isArray(value)) {
-			return await sortedSetAddBulk(key, score, value);
-		}
-		if (!utils.isNumber(score)) {
-			throw new Error(`[[error:invalid-score, ${score}]]`);
-		}
-		value = helpers.valueToString(value);
-
-		try {
-			await module.client.collection('objects').updateOne({ _key: key, value: value }, { $set: { score: parseFloat(score) } }, { upsert: true });
-		} catch (err) {
-			if (err && err.message.includes('E11000 duplicate key error')) {
-				console.log(new Error('e11000').stack, key, score, value);
-				return await module.sortedSetAdd(key, score, value);
+	function normalizeScores(keys, scores) {
+		const isArray = Array.isArray(scores);
+		if (!isArray) {
+			if (!utils.isNumber(scores)) {
+				throw new Error(`[[error:invalid-score, ${scores}]]`);
 			}
-			throw err;
+			return { isArrayOfScores: false, scores };
 		}
-	};
 
-	async function sortedSetAddBulk(key, scores, values) {
-		if (!scores.length || !values.length) {
-			return;
-		}
-		if (scores.length !== values.length) {
+		if (scores.length !== keys.length) {
 			throw new Error('[[error:invalid-data]]');
 		}
-		for (let i = 0; i < scores.length; i += 1) {
-			if (!utils.isNumber(scores[i])) {
-				throw new Error(`[[error:invalid-score, ${scores[i]}]]`);
-			}
-		}
-		values = values.map(helpers.valueToString);
 
-		const bulk = module.client.collection('objects').initializeUnorderedBulkOp();
-		for (let i = 0; i < scores.length; i += 1) {
-			bulk.find({ _key: key, value: values[i] }).upsert().updateOne({ $set: { score: parseFloat(scores[i]) } });
-		}
-		await bulk.execute();
-	}
-
-	module.sortedSetsAdd = async function (keys, scores, value) {
-		if (!Array.isArray(keys) || !keys.length) {
-			return;
-		}
-		const isArrayOfScores = Array.isArray(scores);
-		if ((!isArrayOfScores && !utils.isNumber(scores)) ||
-			(isArrayOfScores && scores.map(s => utils.isNumber(s)).includes(false))) {
+		if (!scores.every(utils.isNumber)) {
 			throw new Error(`[[error:invalid-score, ${scores}]]`);
 		}
 
-		if (isArrayOfScores && scores.length !== keys.length) {
-			throw new Error('[[error:invalid-data]]');
+		return { isArrayOfScores: true, scores };
+	}
+
+	module.sortedSetsAdd = async function (keys, scores, value) {
+		console.log('HELEN sortedSetsAdd hit');
+		if (!Array.isArray(keys) || !keys.length) {
+			return;
 		}
 
+		const { isArrayOfScores, scores: normalizedScores } = normalizeScores(keys, scores);
 		value = helpers.valueToString(value);
 
 		const bulk = module.client.collection('objects').initializeUnorderedBulkOp();
 		for (let i = 0; i < keys.length; i += 1) {
+			const score = isArrayOfScores ? normalizedScores[i] : normalizedScores;
 			bulk
 				.find({ _key: keys[i], value: value })
 				.upsert()
-				.updateOne({ $set: { score: parseFloat(isArrayOfScores ? scores[i] : scores) } });
+				.updateOne({ $set: { score: parseFloat(score) } });
 		}
 		await bulk.execute();
 	};
@@ -78,13 +48,17 @@ module.exports = function (module) {
 		if (!Array.isArray(data) || !data.length) {
 			return;
 		}
+
 		const bulk = module.client.collection('objects').initializeUnorderedBulkOp();
-		data.forEach((item) => {
+		for (const item of data) {
 			if (!utils.isNumber(item[1])) {
 				throw new Error(`[[error:invalid-score, ${item[1]}]]`);
 			}
-			bulk.find({ _key: item[0], value: String(item[2]) }).upsert().updateOne({ $set: { score: parseFloat(item[1]) } });
-		});
+			bulk
+				.find({ _key: item[0], value: String(item[2]) })
+				.upsert()
+				.updateOne({ $set: { score: parseFloat(item[1]) } });
+		}
 		await bulk.execute();
 	};
 };


### PR DESCRIPTION
The specific PR with details can be found here: CMU-313/NodeBB#178

We are adding the change from Project 1, to reduce the complexity of the sortedSetsAdd function in src/database/mongo/sorted/add.js, to our team repository.

This closes #18