### PR TITLE
Feature: filter answered/unanswered questions

### DIFF
--- a/nodebb-plugin-topic-type/library.js
+++ b/nodebb-plugin-topic-type/library.js
@@ -1,12 +1,137 @@
 'use strict';
 
+const db = require.main.require('./src/database');
+const topics = require.main.require('./src/topics');
+
 const plugin = module.exports;
 
-plugin.init = async function (params) {
-	// No server-side initialization needed.
-	// The topic type feature is handled entirely client-side:
-	//   - Radio buttons are injected into the composer via static/lib/main.js
-	//   - topicType is added to the submit payload via the filter:composer.submit hook
-	// Server-side logic (adding Question/Note tags based on topicType) lives in
-	//   src/topics/create.js, src/topics/tags.js, and src/api/topics.js
+const ANSWERED_SET_SUFFIX = ':tids:answered';
+const UNANSWERED_SET_SUFFIX = ':tids:unanswered';
+const SCORE = 1;
+
+/**
+ * Check whether the topic has any non-deleted answer posts (replyType === 'answer')
+ * and update cid:${cid}:tids:answered and cid:${cid}:tids:unanswered accordingly.
+ * Only affects question topics.
+ * @param {number|string} tid - Topic id
+ */
+async function recomputeTopicAnswerStatus(tid) {
+	const topic = await topics.getTopicFields(tid, ['cid', 'topicType']);
+	if (!topic || topic.topicType !== 'question') {
+		return;
+	}
+	const cid = topic.cid;
+	const answeredSet = `cid:${cid}${ANSWERED_SET_SUFFIX}`;
+	const unansweredSet = `cid:${cid}${UNANSWERED_SET_SUFFIX}`;
+
+	const pids = await db.getSortedSetRange(`tid:${tid}:posts`, 0, -1);
+	if (!pids.length) {
+		await db.sortedSetRemove([answeredSet, unansweredSet], tid);
+		return;
+	}
+	const keys = pids.map(pid => `post:${pid}`);
+	const postData = await db.getObjectsFields(keys, ['replyType', 'deleted']);
+	const hasAnswer = postData.some(
+		p => p && p.replyType === 'answer' && parseInt(p.deleted, 10) !== 1
+	);
+
+	if (hasAnswer) {
+		await db.sortedSetAdd(answeredSet, SCORE, tid);
+		await db.sortedSetRemove(unansweredSet, tid);
+	} else {
+		await db.sortedSetRemove(answeredSet, tid);
+		await db.sortedSetAdd(unansweredSet, SCORE, tid);
+	}
+}
+
+plugin.init = async function () {
+	// Client-side topic type and reply-type UI is in static/lib/main.js.
+	// Answered/unanswered sets and filter hooks are below.
+};
+
+// ─── Topic list filter (pagination + count) ───────────────────────────────
+
+plugin.filterCategoryTopicsPrepare = async function (data) {
+	if (data.query && (data.query.answerStatus === 'answered' || data.query.answerStatus === 'unanswered')) {
+		data.answerStatus = data.query.answerStatus;
+	}
+	return data;
+};
+
+plugin.filterCategoriesBuildTopicsSortedSet = async function (payload) {
+	const data = payload.data || payload;
+	const answerStatus = data.answerStatus || (data.query && data.query.answerStatus);
+	if (answerStatus !== 'answered' && answerStatus !== 'unanswered') {
+		return payload;
+	}
+	const cid = data.cid;
+	const currentSet = payload.set;
+	const sets = Array.isArray(currentSet) ? [...currentSet] : [currentSet];
+	const filterSet = answerStatus === 'answered'
+		? `cid:${cid}${ANSWERED_SET_SUFFIX}`
+		: `cid:${cid}${UNANSWERED_SET_SUFFIX}`;
+	sets.push(filterSet);
+	return { ...payload, set: sets.length > 1 ? sets : sets[0] };
+};
+
+// ─── Maintain answered/unanswered sets ────────────────────────────────────
+
+plugin.onTopicSave = async function (payload) {
+	const topic = payload.topic;
+	if (!topic || topic.topicType !== 'question') {
+		return;
+	}
+	const cid = topic.cid;
+	const tid = topic.tid;
+	await db.sortedSetAdd(`cid:${cid}${UNANSWERED_SET_SUFFIX}`, SCORE, tid);
+};
+
+plugin.onPostSave = async function (payload) {
+	const post = payload.post;
+	if (!post || post.replyType !== 'answer') {
+		return;
+	}
+	const topic = await topics.getTopicFields(post.tid, ['cid', 'topicType']);
+	if (!topic || topic.topicType !== 'question') {
+		return;
+	}
+	const cid = topic.cid;
+	const tid = post.tid;
+	await db.sortedSetAdd(`cid:${cid}${ANSWERED_SET_SUFFIX}`, SCORE, tid);
+	await db.sortedSetRemove(`cid:${cid}${UNANSWERED_SET_SUFFIX}`, tid);
+};
+
+plugin.onPostEdit = async function (payload) {
+	const post = payload.post;
+	if (!post || !post.tid) {
+		return;
+	}
+	await recomputeTopicAnswerStatus(post.tid);
+};
+
+plugin.onPostDelete = async function (payload) {
+	const post = payload.post;
+	if (!post || !post.tid) {
+		return;
+	}
+	await recomputeTopicAnswerStatus(post.tid);
+};
+
+plugin.onPostRestore = async function (payload) {
+	const post = payload.post;
+	if (!post || !post.tid) {
+		return;
+	}
+	await recomputeTopicAnswerStatus(post.tid);
+};
+
+plugin.onPostsPurge = async function (payload) {
+	const postsData = payload.posts;
+	if (!Array.isArray(postsData) || !postsData.length) {
+		return;
+	}
+	const tids = [...new Set(postsData.map(p => p.tid).filter(Boolean))];
+	for (const tid of tids) {
+		await recomputeTopicAnswerStatus(tid);
+	}
 };

--- a/nodebb-plugin-topic-type/plugin.json
+++ b/nodebb-plugin-topic-type/plugin.json
@@ -1,13 +1,19 @@
 {
-  "id": "nodebb-plugin-topic-type",
-  "name": "Topic Type Selector",
-  "description": "Adds Question/Note radio buttons to the topic composer so that topicType is sent with new topic creation",
-  "version": "1.0.0",
-  "library": "./library.js",
-  "scripts": [
-    "static/lib/main.js"
-  ],
-  "hooks": [
-    { "hook": "static:app.load", "method": "init" }
-  ]
+	"id": "nodebb-plugin-topic-type",
+	"name": "Topic Type Selector",
+	"description": "Adds Question/Note radio buttons to the topic composer and Answered/Unanswered filter for question lists",
+	"version": "1.0.0",
+	"library": "./library.js",
+	"scripts": ["static/lib/main.js"],
+	"hooks": [
+		{ "hook": "static:app.load", "method": "init" },
+		{ "hook": "filter:category.topics.prepare", "method": "filterCategoryTopicsPrepare" },
+		{ "hook": "filter:categories.buildTopicsSortedSet", "method": "filterCategoriesBuildTopicsSortedSet" },
+		{ "hook": "action:topic.save", "method": "onTopicSave" },
+		{ "hook": "action:post.save", "method": "onPostSave" },
+		{ "hook": "action:post.edit", "method": "onPostEdit" },
+		{ "hook": "action:post.delete", "method": "onPostDelete" },
+		{ "hook": "action:post.restore", "method": "onPostRestore" },
+		{ "hook": "action:posts.purge", "method": "onPostsPurge" }
+	]
 }

--- a/nodebb-plugin-topic-type/static/lib/main.js
+++ b/nodebb-plugin-topic-type/static/lib/main.js
@@ -125,9 +125,82 @@
 		injectTopicTypeSelector(data.postContainer, data.composerData);
 	});
 
+	// ── Answered/Unanswered filter dropdown (category question list only) ─
+	function isCategoryQuestionsPage() {
+		if (typeof ajaxify === 'undefined' || !ajaxify.data) {
+			return false;
+		}
+		var t = ajaxify.data.template || {};
+		if (!t.category && !t.world) {
+			return false;
+		}
+		var qs = (window.location.search || '').slice(1);
+		var tagLabel = (ajaxify.data.selectedTag && ajaxify.data.selectedTag.label) || '';
+		var tagValue = (ajaxify.data.selectedTags && ajaxify.data.selectedTags[0]) || '';
+		if (qs.indexOf('tag=Question') !== -1 || tagLabel === 'Question' || tagValue === 'Question') {
+			return true;
+		}
+		return false;
+	}
+
+	function getAnswerStatusFromUrl() {
+		var match = (window.location.search || '').match(/[?&]answerStatus=([^&]+)/);
+		return match ? decodeURIComponent(match[1]) : 'all';
+	}
+
+	function buildUrlWithAnswerStatus(answerStatus) {
+		var params = new URLSearchParams(window.location.search || '');
+		if (answerStatus === 'all') {
+			params.delete('answerStatus');
+		} else {
+			params.set('answerStatus', answerStatus);
+		}
+		params.delete('page');
+		params.set('page', '1');
+		var query = params.toString();
+		var base = window.location.pathname || '';
+		return query ? base + '?' + query : base;
+	}
+
+	function injectAnswerStatusDropdown() {
+		if (!isCategoryQuestionsPage()) {
+			return;
+		}
+		var container = document.querySelector('[component="category/controls"]');
+		if (!container || container.querySelector('[data-component="topic-type-answer-status"]')) {
+			return;
+		}
+		var current = getAnswerStatusFromUrl();
+		var labels = { all: 'All', answered: 'Answered', unanswered: 'Unanswered' };
+		var html = [
+			'<div class="btn-group bottom-sheet" data-component="topic-type-answer-status">',
+			'  <button class="btn btn-ghost btn-sm ff-secondary d-flex gap-2 align-items-center dropdown-toggle" data-bs-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false" aria-label="Filter by answer status">',
+			'    <span class="d-none d-md-inline fw-semibold">' + (labels[current] || 'All') + '</span>',
+			'  </button>',
+			'  <ul class="dropdown-menu p-1 text-sm" role="menu">',
+			['all', 'answered', 'unanswered'].map(function (value) {
+				var active = current === value ? ' active' : '';
+				var href = buildUrlWithAnswerStatus(value);
+				return '<li><a class="dropdown-item rounded-1' + active + '" href="' + href + '" data-answer-status="' + value + '" role="menuitem">' + labels[value] + '</a></li>';
+			}).join(''),
+			'  </ul>',
+			'</div>'
+		].join('');
+		container.insertAdjacentHTML('afterbegin', html);
+
+		container.querySelectorAll('[data-component="topic-type-answer-status"] [data-answer-status]').forEach(function (link) {
+			link.addEventListener('click', function (e) {
+				e.preventDefault();
+				var val = link.getAttribute('data-answer-status');
+				ajaxify.go(buildUrlWithAnswerStatus(val));
+			});
+		});
+	}
+
 	// ── Hook: topic page loaded (inject reply-type selector + badges) ────
 	$(window).on('action:ajaxify.end', function () {
 		onTopicPageReady();
+		injectAnswerStatusDropdown();
 	});
 
 	// ── Hook: new posts added (e.g. nested replies, new post) ─────────────


### PR DESCRIPTION
## What?

Adds an Answered / Unanswered / All filter for Question-tagged topics on category (and world) topic lists.
A topic is considered Answered if it has at least one non-deleted reply marked as Answer (replyType="answer"); otherwise it’s Unanswered.

## Why?

TAs/instructors (and students) often need to quickly find which questions still need help. Without this, they must scan every Question topic manually. This feature makes triage faster by letting users filter the Question list by answer status.

## How?

Implemented plugin-only changes (no core edits):

- Backend (nodebb-plugin-topic-type/library.js + plugin.json)
  - Maintains two per-category sorted sets:
    - `cid:${cid}:tids:answered`
    - `cid:${cid}:tids:unanswered`
  - Updates these sets on relevant hooks:
    - `action:topic.save` (new Question → Unanswered)
    - `action:post.save` (Answer reply → Answered)
    - `action:post.edit`, `action:post.delete`, `action:post.restore`, `action:posts.purge`
      - recompute status by scanning posts under `tid:${tid}:posts`
- Frontend (nodebb-plugin-topic-type/static/lib/main.js)
  - Adds Answered / Unanswered / All dropdown on Question-tagged topic lists
  - Navigates with `answerStatus=answered|unanswered` and preserves other params


## Testing?
- Verified via UI:
  - New Question topic shows in Unanswered
  - Adding an Answer reply moves it to Answered
  - Deleting/restoring Answer updates status correctly
- Confirmed filters work with `answerStatus=answered|unanswered` while preserving `tag[]` and pagination

## Screenshots?

Screenshot 1 (Question tag + dropdown):
**Usage: Go to a category → click Question tag → then use All / Answered / Unanswered.**
<img width="1688" height="943" alt="Screenshot 2026-02-07 at 8 38 25 PM" src="https://github.com/user-attachments/assets/b685542d-735a-4237-a258-96d03e079151" />

Screenshot 2 (Unanswered list):
With answerStatus=unanswered, only Question topics with no non-deleted Answer replies appear.
<img width="1688" height="943" alt="Screenshot 2026-02-07 at 8 38 48 PM" src="https://github.com/user-attachments/assets/152e8e82-2adc-477c-8149-c09fd404d543" />

Screenshot 3 (Answered List):
Inside the topic, a reply is posted as an Answer (replyType=answer), which should mark the topic as Answered.
With answerStatus=answered, the topic appears in the Answered list, confirming the filter works end-to-end.
<img width="1688" height="943" alt="Screenshot 2026-02-07 at 8 39 01 PM" src="https://github.com/user-attachments/assets/aa6b85ef-abcd-4401-8130-a38ea16289ee" />
<img width="1688" height="943" alt="Screenshot 2026-02-07 at 8 38 57 PM" src="https://github.com/user-attachments/assets/a9b6dd8b-bd71-423b-9e13-d6d3b9a33de4" />

Screenshot 4 (Delete/restore behavior):
After deleting/restoring the Answer reply, the topic correctly moves between Answered and Unanswered.
<img width="1600" height="943" alt="Screenshot 2026-02-07 at 8 43 15 PM" src="https://github.com/user-attachments/assets/c9fb211f-0cf6-4c08-9792-852be380c06b" />
<img width="1688" height="943" alt="Screenshot 2026-02-07 at 8 39 23 PM" src="https://github.com/user-attachments/assets/ef89d2ea-76f2-4561-92dd-53bb86fc945d" />



## Anything else?

Closes #7 