### PR TITLE
Bugfix: show answered/unanswered filter on category pages

### DIFF
--- a/nodebb-plugin-topic-type/static/lib/main.js
+++ b/nodebb-plugin-topic-type/static/lib/main.js
@@ -125,22 +125,13 @@
 		injectTopicTypeSelector(data.postContainer, data.composerData);
 	});
 
-	// ── Answered/Unanswered filter dropdown (category question list only) ─
-	function isCategoryQuestionsPage() {
+	// ── Answered/Unanswered filter (always on category/world; selecting switches to Question + filter) ─
+	function isCategoryOrWorldPage() {
 		if (typeof ajaxify === 'undefined' || !ajaxify.data) {
 			return false;
 		}
 		var t = ajaxify.data.template || {};
-		if (!t.category && !t.world) {
-			return false;
-		}
-		var qs = (window.location.search || '').slice(1);
-		var tagLabel = (ajaxify.data.selectedTag && ajaxify.data.selectedTag.label) || '';
-		var tagValue = (ajaxify.data.selectedTags && ajaxify.data.selectedTags[0]) || '';
-		if (qs.indexOf('tag=Question') !== -1 || tagLabel === 'Question' || tagValue === 'Question') {
-			return true;
-		}
-		return false;
+		return !!(t.category || t.world);
 	}
 
 	function getAnswerStatusFromUrl() {
@@ -148,8 +139,13 @@
 		return match ? decodeURIComponent(match[1]) : 'all';
 	}
 
+	/**
+	 * Build URL for answer-status filter. Uses same codepath as tag filter: always sets tag=Question
+	 * so topic type is "question". All = all questions (no answerStatus); Answered/Unanswered add that param.
+	 */
 	function buildUrlWithAnswerStatus(answerStatus) {
 		var params = new URLSearchParams(window.location.search || '');
+		params.set('tag', 'Question');
 		if (answerStatus === 'all') {
 			params.delete('answerStatus');
 		} else {
@@ -163,7 +159,7 @@
 	}
 
 	function injectAnswerStatusDropdown() {
-		if (!isCategoryQuestionsPage()) {
+		if (!isCategoryOrWorldPage()) {
 			return;
 		}
 		var container = document.querySelector('[component="category/controls"]');


### PR DESCRIPTION
## What?

Adds an Answered / Unanswered / All filter dropdown on category topic list pages.Selecting an option automatically filters Question-tagged topics by adding tag=Question. 
Clicking: All → shows all Question topics; Answered → shows answered Question topics; Unanswered → shows unanswered Question topics
   
## Why?

Users shouldn’t have to manually click the Question tag first just to discover the filter. Showing the dropdown by default on category pages makes it easier to quickly triage questions and find unanswered ones.

## How?

Implemented frontend-only plugin changes (no backend/core changes):

Frontend (nodebb-plugin-topic-type/static/lib/main.js): Always injects the dropdown on category pages (not gated behind already being on the Question tag page). On selection, navigates via ajaxify.go() and builds a URL that: always sets tag=Question; sets answerStatus=answered|unanswered for those options; removes answerStatus for All; preserves other existing params (e.g., sort) and resets page=1

## Testing?

Verified via UI: Dropdown is visible on category/world topic list pages without selecting the Question tag first; All/Answered/Unanswered updates the list correctly; URL updates to include tag=Question and the expected answerStatus value; Navigation stays in sync using ajaxify.go()

## Screenshots?

Screenshot 1: Dropdown visible on category page
<img width="1667" height="933" alt="Screenshot 2026-02-12 at 4 49 08 PM" src="https://github.com/user-attachments/assets/70480bae-f4c5-45e0-8dc3-5c9fe5e3da4a" />

Screenshot 2: Answered/Unanswered filtering applied
<img width="1667" height="933" alt="Screenshot 2026-02-12 at 4 47 28 PM" src="https://github.com/user-attachments/assets/3cbefedc-d559-4b60-b035-d5284de3f387" />

## Anything Else?
Closes #24