### PR TITLE
Feature: Filtering for answer/comment replies within a question post

### DIFF
--- a/nodebb-plugin-topic-type/plugin.json
+++ b/nodebb-plugin-topic-type/plugin.json
@@ -1,7 +1,7 @@
 {
 	"id": "nodebb-plugin-topic-type",
 	"name": "Topic Type Selector",
-	"description": "Adds Question/Note radio buttons to the topic composer and Answered/Unanswered filter for question lists",
+	"description": "Adds Question/Note radio buttons to the topic composer, Answered/Unanswered filter for question lists, and All/Answers/Comments reply filter on question topic pages",
 	"version": "1.0.0",
 	"library": "./library.js",
 	"scripts": ["static/lib/main.js"],

--- a/nodebb-plugin-topic-type/static/lib/main.js
+++ b/nodebb-plugin-topic-type/static/lib/main.js
@@ -7,9 +7,11 @@
  * 2. Reads the selected value and adds `topicType` to the API payload on submit.
  * 3. On question topic pages: injects Answer/Comment selector into quick reply (core quickreply.js reads it and sends replyType).
  * 4. On question topic pages: injects Answer/Comment selector into the main reply composer (filter:composer.submit sends replyType).
- * 5. On question topic pages: injects Answer/Comment badges into each post header (no .tpl changes).
+ * 5. On question topic pages: injects Answer/Comment badges into each post header (no .tpl changes), including new replies without refresh.
+ * 6. On question topic pages: injects a reply filter dropdown (All / Answers / Comments) above the post list (no .tpl changes).
  * Note: For note topics, reply type is always comment and no selector is shown.
  */
+
 (function () {
 	// ── HTML for the composer topic type radio group ─────────────────────
 	var radioHTML = [
@@ -118,10 +120,15 @@
 		if (!post || !post.pid || (post.replyType !== 'answer' && post.replyType !== 'comment')) {
 			return;
 		}
+
 		var postEl = document.querySelector('[component="post"][data-pid="' + post.pid + '"]');
 		if (!postEl) {
 			return;
 		}
+
+		// Needed for reply filtering (All / Answers / Comments)
+		postEl.setAttribute('data-reply-type', post.replyType);
+
 		var header = postEl.querySelector('.post-header');
 		if (!header) {
 			return;
@@ -157,6 +164,89 @@
 		});
 	}
 
+
+	// ── Reply filter (All / Answers / Comments) on question topic pages ───
+	var REPLY_FILTER_KEY = 'topicReplyFilter';
+
+	function getReplyFilter() {
+		try {
+			var tid = (typeof ajaxify !== 'undefined' && ajaxify.data && ajaxify.data.tid) ? String(ajaxify.data.tid) : '';
+			var raw = tid ? (sessionStorage.getItem(REPLY_FILTER_KEY + '_' + tid) || 'all') : 'all';
+			return (raw === 'answer' || raw === 'comment') ? raw : 'all';
+		} catch (e) {
+			return 'all';
+		}
+	}
+
+	function setReplyFilter(value) {
+		try {
+			var tid = (typeof ajaxify !== 'undefined' && ajaxify.data && ajaxify.data.tid) ? String(ajaxify.data.tid) : '';
+			if (tid) {
+				sessionStorage.setItem(REPLY_FILTER_KEY + '_' + tid, value);
+			}
+		} catch (e) {}
+	}
+
+	function applyReplyFilter() {
+		if (typeof ajaxify === 'undefined' || !ajaxify.data || ajaxify.data.topicType !== 'question') {
+			return;
+		}
+		var filter = getReplyFilter();
+		var topicEl = document.querySelector('[component="topic"]');
+		if (!topicEl) {
+			return;
+		}
+		var postEls = topicEl.querySelectorAll('[component="post"]');
+		postEls.forEach(function (el, index) {
+			var replyType = el.getAttribute('data-reply-type');
+			var isFirstPost = index === 0;
+			if (isFirstPost || !replyType) {
+				el.style.display = '';
+				el.style.visibility = '';
+				return;
+			}
+			var show = filter === 'all' || replyType === filter;
+			el.style.display = show ? '' : 'none';
+			el.style.visibility = show ? '' : 'hidden';
+		});
+	}
+
+	function injectReplyFilterDropdown() {
+		if (typeof ajaxify === 'undefined' || !ajaxify.data || ajaxify.data.topicType !== 'question') {
+			return;
+		}
+		var topicList = document.querySelector('[component="topic"]');
+		if (!topicList || document.querySelector('[data-component="topic-type-reply-filter"]')) {
+			return;
+		}
+		var current = getReplyFilter();
+		var labels = { all: 'All', answer: 'Answers', comment: 'Comments' };
+		var html = [
+			'<div class="d-flex align-items-center gap-2 py-2" data-component="topic-type-reply-filter">',
+			'  <label class="text-muted small mb-0">Filter replies</label>',
+			'  <div class="btn-group btn-group-sm" role="group">',
+			'    <select class="form-select form-select-sm" style="width: auto; min-width: 7rem;" data-reply-filter-select aria-label="Filter by reply type">',
+			['all', 'answer', 'comment'].map(function (value) {
+				var selected = current === value ? ' selected' : '';
+				return '<option value="' + value + '"' + selected + '>' + (labels[value] || value) + '</option>';
+			}).join(''),
+			'    </select>',
+			'  </div>',
+			'</div>'
+		].join('');
+		topicList.insertAdjacentHTML('beforebegin', html);
+
+		var selectEl = document.querySelector('[data-component="topic-type-reply-filter"] [data-reply-filter-select]');
+		if (selectEl) {
+			selectEl.addEventListener('change', function () {
+				var val = selectEl.value;
+				setReplyFilter(val);
+				applyReplyFilter();
+			});
+		}
+		applyReplyFilter();
+	}
+
 	// ── Run topic-page logic (quick reply selector + badges) ──────────────
 	function onTopicPageReady() {
 		if (typeof ajaxify === 'undefined' || !ajaxify.data || !ajaxify.data.tid) {
@@ -164,6 +254,9 @@
 		}
 		injectQuickReplyTypeSelector();
 		injectReplyTypeBadges();
+		if (ajaxify.data.topicType === 'question') {
+			injectReplyFilterDropdown();
+		}
 	}
 
 	// ── Hook: composer loaded ────────────────────────────────────────────
@@ -246,37 +339,45 @@
 		injectAnswerStatusDropdown();
 	});
 
-	// ── Hook: new posts added (e.g. nested replies, new post) ─────────────
-	require(['hooks'], function (hooks) {
-		hooks.on('action:posts.loaded', function (payload) {
-			// Use payload posts when present (new reply / load more) so reply-type badge appears without refresh
-			var posts = payload && payload.posts;
-			injectReplyTypeBadges(posts);
-		});
-		hooks.on('action:quickreply.success', function (payload) {
-			if (payload && payload.data && payload.data.pid) {
-				setTimeout(function () {
-					injectReplyTypeBadgeForPost(payload.data);
-				}, 0);
-			}
-		});
-
-		hooks.on('filter:composer.submit', function (hookData) {
-			if (hookData.action === 'topics.post') {
-				var selected = hookData.composerEl
-					.find('input[name="topic-type"]:checked')
-					.val();
-				if (selected) {
-					hookData.composerData.topicType = selected;
+		// ── Hook: new posts added (e.g. nested replies, new post) ─────────────
+		require(['hooks'], function (hooks) {
+			hooks.on('action:posts.loaded', function (payload) {
+				// Use payload posts when present (new reply / load more) so reply-type badge appears without refresh
+				var posts = payload && payload.posts;
+				injectReplyTypeBadges(posts);
+				applyReplyFilter();
+			});
+	
+			hooks.on('action:quickreply.success', function (payload) {
+				if (payload && payload.data && payload.data.pid) {
+					setTimeout(function () {
+						injectReplyTypeBadgeForPost(payload.data);
+						applyReplyFilter();
+					}, 0);
+				} else {
+					setTimeout(function () {
+						injectReplyTypeBadges();
+						applyReplyFilter();
+					}, 0);
 				}
-			}
-			if (hookData.action === 'posts.reply') {
-				// Question topics: read from injected selector; note topics: no selector, default to comment
-				// Match [component="..."] (theme convention), not [data-component="..."]
-				var replyTypeEl = hookData.composerEl.find('[component="composer/reply-type"] input[name="composerReplyType"]:checked');
-				hookData.composerData.replyType = replyTypeEl.length ? replyTypeEl.val() : 'comment';
-			}
-			return hookData;
+			});
+	
+			hooks.on('filter:composer.submit', function (hookData) {
+				if (hookData.action === 'topics.post') {
+					var selected = hookData.composerEl
+						.find('input[name="topic-type"]:checked')
+						.val();
+					if (selected) {
+						hookData.composerData.topicType = selected;
+					}
+				}
+				if (hookData.action === 'posts.reply') {
+					// Question topics: read from injected selector; note topics: no selector, default to comment
+					// Match [component="..."] (theme convention), not [data-component="..."]
+					var replyTypeEl = hookData.composerEl.find('[component="composer/reply-type"] input[name="composerReplyType"]:checked');
+					hookData.composerData.replyType = replyTypeEl.length ? replyTypeEl.val() : 'comment';
+				}
+				return hookData;
+			});
 		});
-	});
-})();
+	})();

--- a/setup-plugins.sh
+++ b/setup-plugins.sh
@@ -16,7 +16,7 @@ REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 
 echo "── Installing local plugins ──────────────────────────────"
 
-# 1. Install the topic-type plugin (Question/Note selector + Answer/Comment reply-type for question topics).
+# 1. Install the topic-type plugin (Question/Note selector, Answer/Comment reply-type, and reply filter for question topics).
 #    Reply type (Answer/Comment) is shown on new replies without refresh (quick reply and main composer).
 
 echo "  → nodebb-plugin-topic-type"


### PR DESCRIPTION
## What?
This feature allows users to filter for answer/comment replies within a question post. In regular note posts, since there are only comments, the filter/UI does not exist.

## Why?
Currently users are able to mark their replies to question posts as answer/comment, but are unable to filter by the type, making it annoying to scroll through different replies until they find answers or comments. With this feature, we wanted to make finding answers to a question very easy and fast so all users can quickly find answers/comments to a question.

## How?
We implemented this feature by making changes to the frontend. Since the replytype already exists as a field of replies, we only needed to add a couple filter functions in the frontend to change what is displayed to the users. These include  getReplytype, setReplytype, applyReplyfilter as helper functions, and made changes to how replies are loaded in. There were no changes to the backend.

## Testing?
Tested this feature through UI and NodeBB tests pass locally.

## Screenshots?
<img width="1899" height="1084" alt="image" src="https://github.com/user-attachments/assets/693d2188-42b4-4d96-83e2-24d17bd791cc" />
<img width="1898" height="1100" alt="image" src="https://github.com/user-attachments/assets/734c52f7-890d-49f1-a75f-f65080639d7c" />
<img width="1909" height="1099" alt="image" src="https://github.com/user-attachments/assets/2319a45b-a42e-4d09-95cc-f777664412fc" />
<img width="1910" height="1105" alt="image" src="https://github.com/user-attachments/assets/e5cb8e13-a41a-4dd3-8bc7-fb2ebf7a5e57" />

## Anything else?
Closes https://github.com/CMU-313/nodebb-spring-26-hall-of-sound/issues/11