### PR TITLE
Bugfix: reply type shows up without page reload

### DIFF
--- a/nodebb-plugin-topic-type/static/lib/main.js
+++ b/nodebb-plugin-topic-type/static/lib/main.js
@@ -110,42 +110,50 @@
 		}
 	}
 
-	// ── Inject Answer/Comment badges into post headers (question topics) ───
-	function injectReplyTypeBadges() {
+	// ── Inject Answer/Comment badge for a single post (by pid + replyType) ─
+	function injectReplyTypeBadgeForPost(post) {
 		if (typeof ajaxify === 'undefined' || !ajaxify.data || ajaxify.data.topicType !== 'question') {
 			return;
 		}
-		var posts = ajaxify.data.posts;
-		if (!Array.isArray(posts)) {
+		if (!post || !post.pid || (post.replyType !== 'answer' && post.replyType !== 'comment')) {
 			return;
 		}
-		posts.forEach(function (post) {
-			if (!post || !post.pid || (post.replyType !== 'answer' && post.replyType !== 'comment')) {
-				return;
-			}
-			var postEl = document.querySelector('[component="post"][data-pid="' + post.pid + '"]');
-			if (!postEl) {
-				return;
-			}
-			var header = postEl.querySelector('.post-header');
-			if (!header) {
-				return;
-			}
-			var firstRow = header.querySelector('.d-flex.gap-1.flex-wrap');
-			if (!firstRow) {
-				firstRow = header.firstElementChild;
-			}
-			if (!firstRow) {
-				return;
-			}
-			if (firstRow.querySelector('[data-topic-type-reply-badge]')) {
-				return;
-			}
-			var badge = document.createElement('span');
-			badge.setAttribute('data-topic-type-reply-badge', '1');
-			badge.className = 'badge rounded-1 me-1 ' + (post.replyType === 'answer' ? 'bg-success' : 'bg-secondary');
-			badge.textContent = post.replyType === 'answer' ? 'Answer' : 'Comment';
-			firstRow.insertBefore(badge, firstRow.firstChild);
+		var postEl = document.querySelector('[component="post"][data-pid="' + post.pid + '"]');
+		if (!postEl) {
+			return;
+		}
+		var header = postEl.querySelector('.post-header');
+		if (!header) {
+			return;
+		}
+		var firstRow = header.querySelector('.d-flex.gap-1.flex-wrap');
+		if (!firstRow) {
+			firstRow = header.firstElementChild;
+		}
+		if (!firstRow) {
+			return;
+		}
+		if (firstRow.querySelector('[data-topic-type-reply-badge]')) {
+			return;
+		}
+		var badge = document.createElement('span');
+		badge.setAttribute('data-topic-type-reply-badge', '1');
+		badge.className = 'badge rounded-1 me-1 ' + (post.replyType === 'answer' ? 'bg-success' : 'bg-secondary');
+		badge.textContent = post.replyType === 'answer' ? 'Answer' : 'Comment';
+		firstRow.insertBefore(badge, firstRow.firstChild);
+	}
+
+	// ── Inject Answer/Comment badges into post headers (question topics) ───
+	function injectReplyTypeBadges(posts) {
+		if (typeof ajaxify === 'undefined' || !ajaxify.data || ajaxify.data.topicType !== 'question') {
+			return;
+		}
+		var list = Array.isArray(posts) ? posts : ajaxify.data.posts;
+		if (!Array.isArray(list)) {
+			return;
+		}
+		list.forEach(function (post) {
+			injectReplyTypeBadgeForPost(post);
 		});
 	}
 
@@ -240,11 +248,17 @@
 
 	// ── Hook: new posts added (e.g. nested replies, new post) ─────────────
 	require(['hooks'], function (hooks) {
-		hooks.on('action:posts.loaded', function () {
-			injectReplyTypeBadges();
+		hooks.on('action:posts.loaded', function (payload) {
+			// Use payload posts when present (new reply / load more) so reply-type badge appears without refresh
+			var posts = payload && payload.posts;
+			injectReplyTypeBadges(posts);
 		});
-		hooks.on('action:quickreply.success', function () {
-			setTimeout(injectReplyTypeBadges, 0);
+		hooks.on('action:quickreply.success', function (payload) {
+			if (payload && payload.data && payload.data.pid) {
+				setTimeout(function () {
+					injectReplyTypeBadgeForPost(payload.data);
+				}, 0);
+			}
 		});
 
 		hooks.on('filter:composer.submit', function (hookData) {

--- a/setup-plugins.sh
+++ b/setup-plugins.sh
@@ -16,7 +16,9 @@ REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 
 echo "── Installing local plugins ──────────────────────────────"
 
-# 1. Install the topic-type plugin (Question/Note selector + Answer/Comment reply-type for question topics: quick reply and main reply composer)
+# 1. Install the topic-type plugin (Question/Note selector + Answer/Comment reply-type for question topics).
+#    Reply type (Answer/Comment) is shown on new replies without refresh (quick reply and main composer).
+
 echo "  → nodebb-plugin-topic-type"
 cd "$REPO_ROOT"
 npm install --save "./nodebb-plugin-topic-type"


### PR DESCRIPTION
## What?
This PR is a bug fix for the feature mentioned here: https://github.com/CMU-313/nodebb-spring-26-hall-of-sound/issues/11 and the previous PR mentioned here: https://github.com/CMU-313/nodebb-spring-26-hall-of-sound/pull/22. This bugfix allows the reply type to show up for the author of the reply without reloading the page.

## Why?
It is a little inconvenient that the author of the reply has to reload the page to see the type of the reply they just made. This is mostly a QOL change and does not change any of the underlying functionalities.

## How?
This fix only required changes in the frontend. I refactored the replytype injection function code to instantly display reply types by injecting the reply type to new replies as they are being displayed.

## Testing?
In addition to testing this feature through the UI and NodeBB tests pass locally, a teammate tested this feature as well on their computer to ensure this works for multiple users instead of only for the main contributor.

Closes https://github.com/CMU-313/nodebb-spring-26-hall-of-sound/issues/28