### PR TITLE
Tests: Added tests to the test suite testing replytype properties and replytype filter

### DIFF
--- a/test/replytype.js
+++ b/test/replytype.js
@@ -133,4 +133,102 @@ describe('Reply type', () => {
 			assert.strictEqual(summary[0].replyType, 'answer');
 		});
 	});
+
+	describe('filter by replyType (answers/comments)', () => {
+		let filterTopicTid;
+		let filterTopicPosts;
+
+		/**
+		 * Filter posts by reply type (mirrors client logic in nodebb-plugin-topic-type).
+		 * First post (main) is always included; other posts are included when
+		 * filter === 'all' || post.replyType === filter.
+		 * @param {Array} postsList - List of posts with replyType (main post has none)
+		 * @param {'all'|'answer'|'comment'} filter - Filter value
+		 * @returns {Array} Filtered posts
+		 */
+		function filterPostsByReplyType(postsList, filter) {
+			return postsList.filter((post, index) => {
+				const isFirstPost = index === 0;
+				const replyType = post.replyType || null;
+				if (isFirstPost || !replyType) {
+					return true;
+				}
+				return filter === 'all' || replyType === filter;
+			});
+		}
+
+		before(async () => {
+			const result = await topics.post({
+				uid: adminUid,
+				cid,
+				title: 'Filter test question',
+				content: 'Main post for filter tests.',
+				topicType: 'question',
+			});
+			filterTopicTid = result.topicData.tid;
+
+			await topics.reply({ uid: fooUid, tid: filterTopicTid, content: 'First answer.', replyType: 'answer' });
+			await topics.reply({ uid: fooUid, tid: filterTopicTid, content: 'Second answer.', replyType: 'answer' });
+			await topics.reply({ uid: fooUid, tid: filterTopicTid, content: 'First comment.', replyType: 'comment' });
+			await topics.reply({ uid: fooUid, tid: filterTopicTid, content: 'Second comment.', replyType: 'comment' });
+
+			const topicData = await topics.getTopicData(filterTopicTid);
+			filterTopicPosts = await topics.getTopicPosts(
+				topicData,
+				`tid:${filterTopicTid}:posts`,
+				0,
+				-1,
+				adminUid,
+				false
+			);
+		});
+
+		it('should return all posts when filter is "all"', () => {
+			const filtered = filterPostsByReplyType(filterTopicPosts, 'all');
+			assert.strictEqual(filtered.length, 5, 'should have main post + 4 replies');
+			assert.strictEqual(filtered.length, filterTopicPosts.length);
+		});
+
+		it('should return only main post and answers when filter is "answer"', () => {
+			const filtered = filterPostsByReplyType(filterTopicPosts, 'answer');
+			assert.strictEqual(filtered.length, 3, 'main post + 2 answers');
+			assert.ok(filtered.every((p, i) => i === 0 || p.replyType === 'answer'));
+			const answers = filtered.filter(p => p.replyType === 'answer');
+			assert.strictEqual(answers.length, 2);
+		});
+
+		it('should return only main post and comments when filter is "comment"', () => {
+			const filtered = filterPostsByReplyType(filterTopicPosts, 'comment');
+			assert.strictEqual(filtered.length, 3, 'main post + 2 comments');
+			assert.ok(filtered.every((p, i) => i === 0 || p.replyType === 'comment'));
+			const comments = filtered.filter(p => p.replyType === 'comment');
+			assert.strictEqual(comments.length, 2);
+		});
+
+		it('should always include first post (main) regardless of filter', () => {
+			const mainPid = filterTopicPosts[0] && filterTopicPosts[0].pid;
+			assert.ok(mainPid);
+			for (const filter of ['all', 'answer', 'comment']) {
+				const filtered = filterPostsByReplyType(filterTopicPosts, filter);
+				assert.ok(filtered.length >= 1);
+				assert.strictEqual(filtered[0].pid, mainPid);
+				assert.ok(!filtered[0].replyType || filtered[0].replyType === undefined);
+			}
+		});
+
+		it('should exclude answers when filter is "comment" and vice versa', () => {
+			const byAnswer = filterPostsByReplyType(filterTopicPosts, 'answer');
+			const byComment = filterPostsByReplyType(filterTopicPosts, 'comment');
+			const answerPids = new Set(byAnswer.filter(p => p.replyType === 'answer').map(p => p.pid));
+			const commentPids = new Set(byComment.filter(p => p.replyType === 'comment').map(p => p.pid));
+			assert.strictEqual(answerPids.size, 2);
+			assert.strictEqual(commentPids.size, 2);
+			for (const pid of answerPids) {
+				assert.ok(!commentPids.has(pid), 'answer pid should not appear in comment filter');
+			}
+			for (const pid of commentPids) {
+				assert.ok(!answerPids.has(pid), 'comment pid should not appear in answer filter');
+			}
+		});
+	});
 });


### PR DESCRIPTION
## What?
Added tests to the test suite to test replytype and replytype filter

## Why?
There are currently no tests in the test suite that test the new replytype and its functionalities.

## How?
Tested the following features:
1. On question posts
     a. Selecting 'answer' for a reply stores the replytype of 'answer' for the reply
     b. Selecting 'comment' for a reply stores the replytype of 'comment' for the reply
2. All replies default to 'comment'
3. replytype is case-friendly and any invalid replytype should be rejected
4. For filtering, mirrored the code from the plugin, and checked that in all cases (answers/comments/all), the correct replies were showing up.

## Testing?
NodeBB tests pass locally.

## CI Coverage

All checks pass, except CI coverage at the end due to Coveralls being down. Here is the summary from a local test.
Statements   : 83.54% ( 26447/31655 )
Branches     : 70.28% ( 11724/16680 )
Functions    : 85.47% ( 4786/5599 )
Lines        : 83.69% ( 25467/30427 )